### PR TITLE
Exclude folder from regular backup because too big

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -214,7 +214,6 @@
                 "dsn": "https://52227cfa250b49e99b1f28408273402c@sentry.iobroker.net/122"
             }
         },
-        "dataFolder": "esphome.%INSTANCE%",
         "localLink": "http://%ESPHomeDashboardIP%:%ESPHomeDashboardPort%",
         "adminTab": {
             "link": "http://%ESPHomeDashboardIP%:%ESPHomeDashboardPort%",


### PR DESCRIPTION
... we should add it to backitup as "custom backup" option and then also only backup whats needed (e.g. the yaml files)