### PR TITLE
Fixed the missing "number"

### DIFF
--- a/main.js
+++ b/main.js
@@ -409,6 +409,10 @@ class Esphome extends utils.Adapter {
 								case 'Switch':
 									await this.handleRegularState(`${host}`, entity, state, true );
 									break;
+									
+								case 'Number':
+									await this.handleRegularState(`${host}`, entity, state, true );
+									break;
 
 								default:
 
@@ -737,7 +741,8 @@ class Esphome extends utils.Adapter {
 				// console.log(`An attribute has changed : ${state}`);
 				await this.extendObjectAsync(objName, {
 					type: 'state',
-					common
+					common,
+					native: {}
 				});
 
 			} else {
@@ -988,6 +993,10 @@ class Esphome extends utils.Adapter {
 				} else if (this.deviceInfo[deviceIP][device[4]].type === `Climate`) {
 					this.deviceInfo[deviceIP][device[4]].states[device[5]] = state.val;
 					await client[deviceIP].connection.climateCommandService(this.deviceInfo[deviceIP][device[4]].states);
+
+					// Handle Number State
+				} else if (this.deviceInfo[deviceIP][device[4]].type === `Number`) {
+					await client[deviceIP].connection.numberCommandService({key: device[4], state: state.val});
 
 					// Handle Cover Position
 				} else if (device[5] === `position`) {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@iobroker/adapter-core": "^2.5.1",
     "@sentry/node": "^5.30.0",
-    "esphome-native-api": "^1.0.9",
+    "@2colors/esphome-native-api": "^1.0.7",
     "nopy": "^0.2.7",
     "tree-kill": "^1.2.2"
   },


### PR DESCRIPTION
include the esphome-native-api fork from [twocolors](https://github.com/twocolors/esphome-native-api/).
It has the most entities includet. It has also many connection-fixes. With this fork i have no more disconnect.

Include in the first step only the number entitie (i need it for myself ;-) ). Perhaps later i will include more.

include also the missing "native" to the states.

This Pull request should close many issues( #136, #148, #147, #134, #132).