### PR TITLE
add friendlyName as common.desc

### DIFF
--- a/main.js
+++ b/main.js
@@ -465,7 +465,9 @@ class Esphome extends utils.Adapter {
 							name: deviceInfo.name,
 							statusStates: {
 								onlineId: `${this.namespace}.${deviceName}.info._online`
-							}
+							},
+							//@ts-ignore js-controller issue erstellt
+							desc: deviceInfo.friendlyName,
 						},
 						native: {
 							ip: host,


### PR DESCRIPTION
This has the least impact on the code and makes the friendly_name available. 