### PR TITLE
add support for text device type

### DIFF
--- a/main.js
+++ b/main.js
@@ -641,6 +641,11 @@ class Esphome extends utils.Adapter {
 									await this.handleRegularState(`${host}`, entity, state, true);
 									break;
 
+								case 'Text': {
+									await this.handleRegularState(`${host}`, entity, state, true);
+									break;
+								}
+
 								case 'Select': {
 									await this.handleRegularState(`${host}`, entity, state, true);
 									break;
@@ -1474,6 +1479,10 @@ class Esphome extends utils.Adapter {
 					// Handle Number State
 				} else if (clientDetails[deviceIP][device[4]].type === `Number`) {
 					await clientDetails[deviceIP].client.connection.numberCommandService({key: device[4], state: state.val});
+
+					// Handle Text State
+				} else if (clientDetails[deviceIP][device[4]].type === `Text`) {
+					await clientDetails[deviceIP].client.connection.textCommandService({key: device[4], state: state.val});
 
 					// Handle Button State
 				} else if (clientDetails[deviceIP][device[4]].type === `Button`) {


### PR DESCRIPTION
Closes https://github.com/DrozmotiX/ioBroker.esphome/issues/141.

Text components are also how displays are handled in esphome.
So also closes https://github.com/DrozmotiX/ioBroker.esphome/issues/103

Usage example for display:
```yaml
text:
  - platform: template
    id: display_text
    name: "Template text"
    optimistic: true
    mode: text

display:
  - platform: ssd1306_i2c
    lambda: |-
        it.printf(0, 0, id(font), "%s", id(display_text).state);
```

---

Related issues / discussions about this:
- https://github.com/Nafaya/esphome-native-api/issues/14
- https://github.com/twocolors/esphome-native-api/issues/25
- https://github.com/twocolors/esphome-native-api/commit/476a85f8131412adf57eb22ee7cd03e59c396de1
- https://github.com/esphome/aioesphomeapi/commit/5a8c0d8e2369205126b0995233bd10b6c057c61e
- 