### PR TITLE
update esphome-native-api, actually fix #322

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@2colors/esphome-native-api": "^1.3.5",
         "@iobroker/adapter-core": "^3.3.2",
         "autopy": "^1.1.1",
-        "axios": "^1.12.2",
+        "axios": "^1.13.1",
         "node-fetch": "^3.3.2"
       },
       "devDependencies": {
@@ -24,7 +24,7 @@
         "@iobroker/dev-server": "^0.8.0",
         "@iobroker/testing": "^5.1.1",
         "@types/gulp": "^4.0.17",
-        "@types/node": "^24.6.1",
+        "@types/node": "^24.9.2",
         "eslint": "^8.57.1",
         "gulp": "^4.0.2",
         "promisify": "~0.0.3",
@@ -2420,12 +2420,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.6.1.tgz",
-      "integrity": "sha512-ljvjjs3DNXummeIaooB4cLBKg2U6SPI6Hjra/9rRIy7CpM0HpLtG9HptkMKAb4HYWy5S7HUvJEuWgr/y0U8SHw==",
+      "version": "24.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
+      "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.13.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/picomatch": {
@@ -3167,9 +3167,9 @@
       "dev": true
     },
     "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -12780,9 +12780,9 @@
       "dev": true
     },
     "node_modules/undici-types": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.13.0.tgz",
-      "integrity": "sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "license": "MIT"
     },
     "node_modules/union-value": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@2colors/esphome-native-api": "^1.3.5",
     "@iobroker/adapter-core": "^3.3.2",
     "autopy": "^1.1.1",
-    "axios": "^1.12.2",
+    "axios": "^1.13.1",
     "node-fetch": "^3.3.2"
   },
   "devDependencies": {
@@ -45,7 +45,7 @@
     "@iobroker/dev-server": "^0.8.0",
     "@iobroker/testing": "^5.1.1",
     "@types/gulp": "^4.0.17",
-    "@types/node": "^24.6.1",
+    "@types/node": "^24.9.2",
     "eslint": "^8.57.1",
     "gulp": "^4.0.2",
     "promisify": "~0.0.3",


### PR DESCRIPTION
update esphome-native-api to fix connection with esphome >= 2025.10
Fixes: #322 (issue was actually already closed after downgrade workaround. here is the actual fix for it)