### PR TITLE
add token env variable again to avoid rate limiting. broken by pr #388

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -44,6 +44,9 @@ jobs:
         node-version: [20.x, 22.x, 24.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - uses: ioBroker/testing-action-adapter@v1
         with:


### PR DESCRIPTION
Copilot removed the token environment variable in https://github.com/DrozmotiX/ioBroker.esphome/pull/388. Add again to fix rate limit issues with tests.