### PR TITLE
allow connection to devices running < 2025.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.7.0-beta.4",
       "license": "MIT",
       "dependencies": {
-        "@2colors/esphome-native-api": "github:SimonFischer04/esphome-native-api#d93cf4acdd8885437a133c4369bddcd180030c06",
+        "@2colors/esphome-native-api": "^1.3.6",
         "@iobroker/adapter-core": "^3.3.2",
         "autopy": "github:SimonFischer04/autopy#fbe016f35e13e335e1c44783a1e7273bbb2a08c1"
       },
@@ -32,9 +32,9 @@
       }
     },
     "node_modules/@2colors/esphome-native-api": {
-      "version": "1.3.5",
-      "resolved": "git+ssh://git@github.com/SimonFischer04/esphome-native-api.git#d93cf4acdd8885437a133c4369bddcd180030c06",
-      "integrity": "sha512-iXdfi9fQ7WRRSz2tWAZOHMkj1YerVlGdtON1vJ61PUtLuZWGWzMZzRiyz3cGrO0X3eX1qBGFNk5v4Ue2OTK5Ug==",
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@2colors/esphome-native-api/-/esphome-native-api-1.3.6.tgz",
+      "integrity": "sha512-UnWullIsfmF5txBcgZOKIpAV4ip3Kei+to7YakYX4z1I2mJrYXh91nmhgxH8aIQkqOF0tZDdpuDbRnSb/v68dQ==",
       "license": "MIT",
       "dependencies": {
         "@richardhopton/noise-c.wasm": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "node": ">= 20"
   },
   "dependencies": {
-    "@2colors/esphome-native-api": "github:SimonFischer04/esphome-native-api#d93cf4acdd8885437a133c4369bddcd180030c06",
+    "@2colors/esphome-native-api": "^1.3.6",
     "@iobroker/adapter-core": "^3.3.2",
     "autopy": "github:SimonFischer04/autopy#fbe016f35e13e335e1c44783a1e7273bbb2a08c1"
   },


### PR DESCRIPTION
See https://github.com/twocolors/esphome-native-api/pull/46

Probably also cause of https://github.com/DrozmotiX/ioBroker.esphome/issues/394#issuecomment-3939068030