### PR TITLE
fix broken by copilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ If you like my work, please consider a personal donation
     * (DutchmanNL) 
 -->
 ### __WORK IN PROGRESS__
+* (@SimonFischer04) fix copilot hallucinations
 * (@copilot) **NEW**: Add `lib/dashboardApi.js` module exposing all ESPHome Dashboard API endpoints (`getDevices`, `getConfig`, `getEncryptionKey`, `compile`, `upload`) for tighter dashboard integration
 * (@copilot) **FIXED**: Invalid jsonConfig warning on adapter install caused by `multiline` property not being allowed on `text` type; changed `uploadContent` to use `textarea` type (fixes #426)
 

--- a/admin/jsonConfig.json5
+++ b/admin/jsonConfig.json5
@@ -668,6 +668,7 @@
 				"advanced": {
 					"type": "panel",
 					"label": "Advanced",
+                    "collapsable": true,
 					"xs": 12,
 					"sm": 12,
 					"md": 12,

--- a/main.js
+++ b/main.js
@@ -252,7 +252,7 @@ class Esphome extends utils.Adapter {
             pillowVersions.push(...versions);
 
             // Determine Pillow version to use
-            let usePillowVersion = '11.3.0'; // Default version
+            let usePillowVersion = '12.1.1'; // Default version
 
             // Check if user has configured a specific pillow version
             if (


### PR DESCRIPTION
Wrong warning in admin: https://github.com/DrozmotiX/ioBroker.esphome/issues/384
following this copilot completely halluscinated something together in: https://github.com/DrozmotiX/ioBroker.esphome/pull/385
(collapsible also does not exist in schema) that got merged without checking...

Later the checker rightfully complained in: https://github.com/DrozmotiX/ioBroker.esphome/issues/396 and copilots "fix" was to just remove the feature ...: https://github.com/DrozmotiX/ioBroker.esphome/pull/405/changes


schema wrong. see: https://github.com/ioBroker/ioBroker.admin/issues/3418

---

Also update pillow version again. Workflow correctly detected pillow version mismatch error 🥳.