### PR TITLE
fix 'Always last available' for pillow version

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,6 +394,7 @@ If you like my work, please consider a personal donation
     * (DutchmanNL) 
 -->
 ### __WORK IN PROGRESS__
+* (@SimonFischer04) fix 'Always last available' for pillow version
 * (@SimonFischer04) fix copilot hallucinations
 * (@copilot) **NEW**: Add `lib/dashboardApi.js` module exposing all ESPHome Dashboard API endpoints (`getDevices`, `getConfig`, `getEncryptionKey`, `compile`, `upload`) for tighter dashboard integration
 * (@copilot) **FIXED**: Invalid jsonConfig warning on adapter install caused by `multiline` property not being allowed on `text` type; changed `uploadContent` to use `textarea` type (fixes #426)

--- a/main.js
+++ b/main.js
@@ -252,17 +252,19 @@ class Esphome extends utils.Adapter {
             pillowVersions.push(...versions);
 
             // Determine Pillow version to use
-            let usePillowVersion = '12.1.1'; // Default version
+            let usePillowVersion = '';
 
-            // Check if user has configured a specific pillow version
+            // Use configured version unless "Always last available" is selected
             if (
                 this.config.PillowVersion &&
                 this.config.PillowVersion !== '' &&
                 this.config.PillowVersion !== 'Always last available'
             ) {
                 usePillowVersion = this.config.PillowVersion;
+            } else if (this.config.PillowVersion === 'Always last available' && versions.length > 0) {
+                // Mirror dashboard behavior: pick newest fetched/cached release
+                usePillowVersion = versions[0];
             }
-            // If "Always last available" is selected, keep the default latest version
 
             this.log.debug(`Using Pillow version: ${usePillowVersion}`);
 


### PR DESCRIPTION
'Always last available' did not actually use latest version, but some fixed version before.

Not sure if it's better to include this or not.
CI fails with:
```
The conflict is caused by:
    The user requested pillow==12.2.0
    esphome 2026.3.2 depends on pillow==12.1.1
```

So newest esphome does not work with newest pillow ...
But sometimes newer esphome versions require newer pillow versions ...

Maybe better to manually change pillow version every few times a new esphome releases, until this should be improved with idea outlined in:
https://github.com/DrozmotiX/ioBroker.esphome/pull/183