### PR TITLE
fix: pin dashboard versions for 1.0, warn when unpinned, clear all type errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,10 @@ If you like my work, please consider a personal donation
     * (DutchmanNL)
 -->
 
+### **WORK IN PROGRESS**
+
+- (@SimonFischer04) **FIXED**: New installations now default to ESPHome Dashboard 2026.6.5 and Pillow 12.2.0 instead of the latest available release, the 2026.7.x releases currently fail to install (#463)
+
 ### 1.0.0-beta.1 (2026-07-28)
 
 - (@DutchmanNL) **FIXED**: Restored a green CI matrix, the dashboard integration tests no longer hang the test runner

--- a/README.md
+++ b/README.md
@@ -444,6 +444,7 @@ If you like my work, please consider a personal donation
 ### **WORK IN PROGRESS**
 
 - (@SimonFischer04) **FIXED**: New installations now default to ESPHome Dashboard 2026.6.5 and Pillow 12.2.0 instead of the latest available release, the 2026.7.x releases currently fail to install (#463)
+- (@SimonFischer04) **NEW**: Existing installations still set to "Always last available" get a warning at startup pointing at the versions known to work (#463)
 
 ### 1.0.0-beta.1 (2026-07-28)
 

--- a/README.md
+++ b/README.md
@@ -445,6 +445,9 @@ If you like my work, please consider a personal donation
 
 - (@SimonFischer04) **FIXED**: New installations now default to ESPHome Dashboard 2026.6.5 and Pillow 12.2.0 instead of the latest available release, the 2026.7.x releases currently fail to install (#463)
 - (@SimonFischer04) **NEW**: Existing installations still set to "Always last available" get a warning at startup pointing at the versions known to work (#463)
+- (@DutchmanNL) **FIXED**: Falling back to the latest ESPHome or Pillow release no longer aborts the dashboard setup, the requirement was passed to pip without a version specifier
+- (@DutchmanNL) **FIXED**: Added the missing "pingInterval" and "pingAttempts" defaults to io-package.json, they were only defined in the admin configuration
+- (@DutchmanNL) **ENHANCED**: "npm run check" is free of type errors, so type regressions are visible again
 
 ### 1.0.0-beta.1 (2026-07-28)
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,17 @@ export default [
         ignores: ['.dev-server/**', '.devcontainer/**'],
     },
 
+    {
+        // @iobroker/eslint-config builds on jsdoc's "recommended-typescript" preset, which reports
+        // "@type" and "@typedef" as redundant because TypeScript would carry the type itself. This
+        // adapter is plain JavaScript, type checked through "checkJs" (see tsconfig.json and
+        // "npm run check"), so JSDoc is the only place a type can be expressed.
+        files: ['**/*.js'],
+        rules: {
+            'jsdoc/check-tag-names': ['error', { typed: false }],
+        },
+    },
+
     // Add mocha globals for test files
     {
         files: ['**/*.test.js', 'test/**/*.js'],

--- a/io-package.json
+++ b/io-package.json
@@ -185,6 +185,8 @@
     "ESPHomeDashboardVersion": "Always last available",
     "PillowVersion": "Always last available",
     "reconnectInterval": 30,
+    "pingInterval": 5,
+    "pingAttempts": 1,
     "apiPass": "",
     "apiPassword": "",
     "encryptionKey": "",

--- a/io-package.json
+++ b/io-package.json
@@ -182,8 +182,8 @@
     "apiPassword"
   ],
   "native": {
-    "ESPHomeDashboardVersion": "Always last available",
-    "PillowVersion": "Always last available",
+    "ESPHomeDashboardVersion": "2026.6.5",
+    "PillowVersion": "12.2.0",
     "reconnectInterval": 30,
     "apiPass": "",
     "apiPassword": "",

--- a/lib/dashboardApi.js
+++ b/lib/dashboardApi.js
@@ -58,11 +58,16 @@ async function request(method, dashboardUrl, path, params) {
 async function streamLogs(dashboardUrl, path, spawnParams, lineReceivedCb) {
     const wsUrl = `${dashboardUrl.replace(/\/+$/, '').replace(/^http/, 'ws')}/${path}`;
 
-    // Prefer native WebSocket (Node >= 22), but fall back to "ws" package on older Node versions
+    // Prefer native WebSocket (Node >= 22), but fall back to "ws" package on older Node versions.
+    // Both constructors are used interchangeably here although they expose different APIs
+    // (addEventListener vs. on), which is why the two branches below exist and why the instance
+    // cannot be described by a single type.
     const hasNativeWebSocket = typeof WebSocket !== 'undefined';
-    let WebSocketImpl = hasNativeWebSocket ? WebSocket : null;
+    let WebSocketImpl;
 
-    if (!WebSocketImpl) {
+    if (hasNativeWebSocket) {
+        WebSocketImpl = WebSocket;
+    } else {
         try {
             WebSocketImpl = require('ws');
         } catch {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -18,11 +18,15 @@ class DeviceInfo {
     connectionError = false;
     connectStatus = 'Initialisation needed';
     deletionRequested = false;
+    /** @type {string | null} */
     deviceFriendlyName = null;
     deviceInfo = null;
+    /** @type {string | null} */
     deviceName = null;
     initialized = false;
+    /** @type {string | null} */
     ip = null;
+    /** @type {string | null} */
     mac = null;
 }
 

--- a/lib/yamlFileManager.js
+++ b/lib/yamlFileManager.js
@@ -163,10 +163,11 @@ class YamlFileManager {
                 message: `File ${filename} uploaded successfully`,
             };
         } catch (error) {
+            const reason = error instanceof Error && error.message ? error.message : String(error);
             this.adapter.log.error(`[yamlFileManager.uploadYamlFile] ${error}`);
             return {
                 success: false,
-                error: `Failed to upload file: ${error.message || error}`,
+                error: `Failed to upload file: ${reason}`,
             };
         }
     }
@@ -208,10 +209,11 @@ class YamlFileManager {
                 filename: filename,
             };
         } catch (error) {
+            const reason = error instanceof Error && error.message ? error.message : String(error);
             this.adapter.log.error(`[yamlFileManager.downloadYamlFile] ${error}`);
             return {
                 success: false,
-                error: `Failed to download file: ${error.message || error}`,
+                error: `Failed to download file: ${reason}`,
             };
         }
     }
@@ -253,10 +255,11 @@ class YamlFileManager {
                 message: `File ${filename} deleted successfully`,
             };
         } catch (error) {
+            const reason = error instanceof Error && error.message ? error.message : String(error);
             this.adapter.log.error(`[yamlFileManager.deleteYamlFile] ${error}`);
             return {
                 success: false,
-                error: `Failed to delete file: ${error.message || error}`,
+                error: `Failed to delete file: ${reason}`,
             };
         }
     }

--- a/main.js
+++ b/main.js
@@ -23,6 +23,14 @@ const clientDetails = {}; // Memory cache of all devices and their connection st
 const newlyDiscoveredClient = {}; // Memory cache of all newly discovered devices and their connection status
 const dashboardVersions = [];
 const pillowVersions = []; // Memory cache for available Pillow versions
+
+// Versions new installations are pinned to. ESPHome 2026.7.x currently fails to install for a
+// part of our users (#463), so the defaults point at the last combination known to work instead
+// of "Always last available". Existing installations keep whatever they have configured.
+// Keep in sync with the "native" defaults in io-package.json.
+const defaultDashboardVersion = '2026.6.5';
+const defaultPillowVersion = '12.2.0';
+
 class Esphome extends utils.Adapter {
     /**
      * @param {Partial<utils.AdapterOptions>} [options] - Adapter configuration options
@@ -1725,6 +1733,9 @@ class Esphome extends utils.Adapter {
                                 value: dashboardVersions[versions],
                             });
                         }
+                        // The version new installations default to must always be selectable, also
+                        // when the release list could not be retrieved from GitHub
+                        this.ensureVersionInDropDown(dropDownEntry, defaultDashboardVersion);
 
                         this.sendTo(obj.from, obj.command, dropDownEntry, obj.callback);
                     }
@@ -1747,7 +1758,7 @@ class Esphome extends utils.Adapter {
                         } else {
                             // Fallback versions if cache is empty
                             this.log.info('No cached Pillow versions available, using fallback versions');
-                            const fallbackVersions = ['11.3.0', '11.2.0', '11.1.0', '11.0.0', '10.4.0', '10.3.0'];
+                            const fallbackVersions = ['12.2.0', '12.1.1', '12.0.0', '11.3.0', '11.2.0', '11.1.0'];
                             for (const version of fallbackVersions) {
                                 dropDownEntry.push({
                                     label: version,
@@ -1755,6 +1766,9 @@ class Esphome extends utils.Adapter {
                                 });
                             }
                         }
+                        // The version new installations default to must always be selectable, also
+                        // when the release list could not be retrieved from PyPI
+                        this.ensureVersionInDropDown(dropDownEntry, defaultPillowVersion);
 
                         this.sendTo(obj.from, obj.command, dropDownEntry, obj.callback);
                     }
@@ -1989,12 +2003,26 @@ class Esphome extends utils.Adapter {
     }
 
     /**
+     * Add a version to a dropDown when it is not part of it yet, so a configured version can never
+     * silently disappear from the selection when the release list is unavailable or outdated
+     *
+     * @param {Array<string | {label: string, value: string}>} dropDownEntry - dropDown entries to extend
+     * @param {string} version - version which must be selectable
+     */
+    ensureVersionInDropDown(dropDownEntry, version) {
+        const known = dropDownEntry.some(entry => (typeof entry === 'string' ? entry : entry.value) === version);
+        if (!known) {
+            dropDownEntry.push({ label: version, value: version });
+        }
+    }
+
+    /**
      * Fetch Pillow versions from PyPI and cache them
      *
      * @returns {Promise<string[]>} Array of available Pillow versions
      */
     async fetchAndCachePillowVersions() {
-        const fallbackVersions = ['11.3.0', '11.2.0', '11.1.0', '11.0.0', '10.4.0', '10.3.0'];
+        const fallbackVersions = ['12.2.0', '12.1.1', '12.0.0', '11.3.0', '11.2.0', '11.1.0'];
 
         try {
             const response = await fetch('https://pypi.org/pypi/pillow/json');

--- a/main.js
+++ b/main.js
@@ -9,7 +9,6 @@
 const utils = require('@iobroker/adapter-core');
 const clientDevice = require('./lib/helpers.js');
 const YamlFileManager = require('./lib/yamlFileManager.js');
-// @ts-expect-error Client is just missing in index.d.ts file
 const { Client, Discovery } = require('@2colors/esphome-native-api');
 const stateAttr = require(`${__dirname}/lib/stateAttr.js`); // Load attribute library
 const disableSentry = false; // Ensure to set to true during development!
@@ -152,8 +151,9 @@ class Esphome extends utils.Adapter {
                 // adapter will restart
             }
         } catch (error) {
+            const reason = error instanceof Error && error.message ? error.message : String(error);
             this.log.error(
-                `Error during configuration migration from ESPHomeDashboardIP to ESPHomeDashboardUrl: ${error.message || error}`,
+                `Error during configuration migration from ESPHomeDashboardIP to ESPHomeDashboardUrl: ${reason}`,
             );
         }
     }
@@ -211,7 +211,7 @@ class Esphome extends utils.Adapter {
                 );
                 let cachedVersions = await this.getStateAsync(`_ESPHomeDashboard.versionCache`);
                 if (cachedVersions && cachedVersions.val) {
-                    cachedVersions = JSON.parse(cachedVersions.val);
+                    cachedVersions = JSON.parse(String(cachedVersions.val));
                     for (const version in cachedVersions) {
                         dashboardVersions.push(cachedVersions[version].name);
                     }
@@ -267,10 +267,13 @@ class Esphome extends utils.Adapter {
             if (this.config.ESPHomeDashboardEnabled) {
                 this.log.info(`Native Integration of ESPHome Dashboard enabled, making environment ready`);
                 try {
-                    // @ts-expect-error autopy types are incomplete
                     const { getVenv } = await import('autopy');
                     let python;
                     try {
+                        // "version" must be present on every requirement even when no version is
+                        // pinned: autopy builds the pip argument as `${name}${version}` and passes
+                        // it to pep440 satisfies(), both of which break on undefined. An empty
+                        // specifier means "any version" for both.
                         const requirements = [];
                         if (useDashBoardVersion) {
                             requirements.push({ name: 'esphome', version: `==${useDashBoardVersion}` });
@@ -278,7 +281,7 @@ class Esphome extends utils.Adapter {
                             this.log.warn(
                                 `Unable to determine a specific ESPHome dashboard version. Falling back to latest available version from PyPI`,
                             );
-                            requirements.push({ name: 'esphome' });
+                            requirements.push({ name: 'esphome', version: '' });
                         }
                         if (usePillowVersion) {
                             requirements.push({ name: 'pillow', version: `==${usePillowVersion}` });
@@ -286,7 +289,7 @@ class Esphome extends utils.Adapter {
                             this.log.warn(
                                 `Unable to determine a specific Pillow version. Falling back to latest available version from PyPI`,
                             );
-                            requirements.push({ name: 'pillow' });
+                            requirements.push({ name: 'pillow', version: '' });
                         }
                         // Create a virtual environment with esphome installed.
                         python = await getVenv({
@@ -295,7 +298,8 @@ class Esphome extends utils.Adapter {
                             requirements,
                         });
                     } catch (error) {
-                        this.log.error(`Fatal error starting ESPHomeDashboard | ${error} | ${error.stack}`);
+                        const stack = error instanceof Error ? error.stack : undefined;
+                        this.log.error(`Fatal error starting ESPHomeDashboard | ${error} | ${stack}`);
                         return;
                     }
 
@@ -321,7 +325,7 @@ class Esphome extends utils.Adapter {
                     dashboardProcess = python('esphome', [
                         'dashboard',
                         '--port',
-                        this.config.ESPHomeDashboardPort,
+                        String(this.config.ESPHomeDashboardPort),
                         `${dataDir}esphome.${this.instance}`,
                     ]);
 
@@ -636,7 +640,6 @@ class Esphome extends utils.Adapter {
                             statusStates: {
                                 onlineId: `${this.namespace}.${deviceName}.info._online`,
                             },
-                            // @ts-expect-error js-controller issue - desc should be string but friendlyName may be undefined
                             desc: deviceInfo.friendlyName,
                         },
                         native: {
@@ -944,7 +947,8 @@ class Esphome extends utils.Adapter {
                         this.log.error(`Entity error: ${name}`);
                     });
                 } catch (e) {
-                    this.log.error(`Connection issue for ${entity.name} ${e} | ${e.stack}`);
+                    const stack = e instanceof Error ? e.stack : undefined;
+                    this.log.error(`Connection issue for ${entity.name} ${e} | ${stack}`);
                 }
             });
 
@@ -1030,7 +1034,8 @@ class Esphome extends utils.Adapter {
                 );
             }
         } catch (e) {
-            this.log.error(`ESP device error for ${host} | ${e} | ${e.stack}`);
+            const stack = e instanceof Error ? e.stack : undefined;
+            this.log.error(`ESP device error for ${host} | ${e} | ${stack}`);
         }
     }
 
@@ -1412,7 +1417,6 @@ class Esphome extends utils.Adapter {
                         common.write !== this.createdStatesDetails[objName].write))
             ) {
                 // console.log(`An attribute has changed : ${state}`);
-                // @ts-expect-error values are correctly provided by state Attribute definitions, error can be ignored
                 await this.extendObjectAsync(objName, {
                     type: 'state',
                     common,
@@ -1443,7 +1447,7 @@ class Esphome extends utils.Adapter {
      * Handles error messages for log and Sentry
      *
      * @param {string} codepart Function were exception occurred
-     * @param {Error|string} error Error message
+     * @param {unknown} error Caught value, anything can be thrown in JavaScript
      */
     errorHandler(codepart, error) {
         let errorMsg = error;
@@ -1491,6 +1495,17 @@ class Esphome extends utils.Adapter {
     }
 
     /**
+     * Extract the argument of a modify method, so "multiply(2.5)" yields "2.5"
+     *
+     * @param {string} method defines the method to be executed (e.g. round())
+     * @returns {string} text between the brackets, empty when the method has no argument
+     */
+    modifyArgument(method) {
+        const inBracket = method.match(/(?<=\()(.*?)(?=\))/);
+        return inBracket ? inBracket[0] : '';
+    }
+
+    /**
      * Analysis modify an element in stateAttr.js and execute command
      *
      * @param {string} method defines the method to be executed (e.g. round())
@@ -1505,24 +1520,24 @@ class Esphome extends utils.Adapter {
                 value = eval(method.replace(/^custom:/gi, '')); //get value without "custom:"
             } else if (method.match(/^multiply\(/gi) != null) {
                 //check if starts with "multiply("
-                const inBracket = parseFloat(method.match(/(?<=\()(.*?)(?=\))/g)); //get value in brackets
-                value = value * inBracket;
+                const inBracket = parseFloat(this.modifyArgument(method)); //get value in brackets
+                value = Number(value) * inBracket;
             } else if (method.match(/^divide\(/gi) != null) {
                 //check if starts with "divide("
-                const inBracket = parseFloat(method.match(/(?<=\()(.*?)(?=\))/g)); //get value in brackets
-                value = value / inBracket;
+                const inBracket = parseFloat(this.modifyArgument(method)); //get value in brackets
+                value = Number(value) / inBracket;
             } else if (method.match(/^round\(/gi) != null) {
                 //check if starts with "round("
-                const inBracket = parseInt(method.match(/(?<=\()(.*?)(?=\))/g)); //get value in brackets
-                value = Math.round(value * Math.pow(10, inBracket)) / Math.pow(10, inBracket);
+                const inBracket = parseInt(this.modifyArgument(method)); //get value in brackets
+                value = Math.round(Number(value) * Math.pow(10, inBracket)) / Math.pow(10, inBracket);
             } else if (method.match(/^add\(/gi) != null) {
                 //check if starts with "add("
-                const inBracket = parseFloat(method.match(/(?<=\()(.*?)(?=\))/g)); //get value in brackets
-                value = parseFloat(value) + inBracket;
+                const inBracket = parseFloat(this.modifyArgument(method)); //get value in brackets
+                value = parseFloat(String(value)) + inBracket;
             } else if (method.match(/^substract\(/gi) != null) {
                 //check if starts with "substract("
-                const inBracket = parseFloat(method.match(/(?<=\()(.*?)(?=\))/g)); //get value in brackets
-                value = parseFloat(value) - inBracket;
+                const inBracket = parseFloat(this.modifyArgument(method)); //get value in brackets
+                value = parseFloat(String(value)) - inBracket;
             } else {
                 const methodUC = method.toUpperCase();
                 switch (methodUC) {
@@ -1999,7 +2014,7 @@ class Esphome extends utils.Adapter {
         try {
             const response = await fetch('https://pypi.org/pypi/pillow/json');
             if (response.ok) {
-                const data = await response.json();
+                const data = /** @type {{ releases: Record<string, unknown> }} */ (await response.json());
                 const versions = Object.keys(data.releases)
                     .filter(v => !v.includes('a') && !v.includes('b') && !v.includes('rc')) // Filter out alpha/beta/rc versions
                     .sort((a, b) => {
@@ -2037,16 +2052,15 @@ class Esphome extends utils.Adapter {
                 this.log.warn(`Unable to fetch Pillow versions from PyPI: ${response.status}, using cached values`);
             }
         } catch (error) {
-            this.log.warn(
-                `Error fetching Pillow versions from PyPI: ${error.message}, using cached or fallback versions`,
-            );
+            const reason = error instanceof Error && error.message ? error.message : String(error);
+            this.log.warn(`Error fetching Pillow versions from PyPI: ${reason}, using cached or fallback versions`);
         }
 
         // Try to load from cache
         try {
             const cachedPillowVersions = await this.getStateAsync(`_ESPHomeDashboard.pillowVersionCache`);
             if (cachedPillowVersions && cachedPillowVersions.val) {
-                const versions = JSON.parse(cachedPillowVersions.val);
+                const versions = JSON.parse(String(cachedPillowVersions.val));
                 this.log.info(`Loaded ${versions.length} Pillow versions from cache`);
                 return versions;
             }
@@ -2078,7 +2092,8 @@ class Esphome extends utils.Adapter {
                 this.log.info('Autopy cache directory does not exist');
             }
         } catch (error) {
-            this.log.error(`Error clearing autopy cache: ${error.message}`);
+            const reason = error instanceof Error && error.message ? error.message : String(error);
+            this.log.error(`Error clearing autopy cache: ${reason}`);
             throw error;
         }
     }
@@ -2256,7 +2271,7 @@ class Esphome extends utils.Adapter {
                         device[5] === `warmWhite`
                     ) {
                         // Convert value to 255 range
-                        writeValue = writeValue / 100 / 2.55;
+                        writeValue = Number(writeValue) / 100 / 2.55;
 
                         // Store value to memory
                         clientDetails[deviceIP][device[4]].states[device[5]] = writeValue;
@@ -2309,7 +2324,7 @@ class Esphome extends utils.Adapter {
                     // Auto white channel: when colorHEX is set to white (#ffffff) on RGBW lights,
                     // automatically switch to white channel; otherwise switch to RGB mode
                     if (clientDetails[deviceIP][device[4]].rgbAutoWhite && supportsWhite && device[5] === 'colorHEX') {
-                        if (writeValue.replace(/^#/, '').toLowerCase() === 'ffffff') {
+                        if (String(writeValue).replace(/^#/, '').toLowerCase() === 'ffffff') {
                             // White color detected: redirect to dedicated white channel
                             clientDetails[deviceIP][device[4]].states.red = 0;
                             clientDetails[deviceIP][device[4]].states.green = 0;
@@ -2438,7 +2453,6 @@ class Esphome extends utils.Adapter {
             const _channels = await this.getObjectViewAsync('system', 'channel', params);
             // List all found channels & compare with memory, delete unneeded channels
             for (const currDevice in _channels.rows) {
-                // @ts-expect-error _channels.rows is an array but treated as object here
                 if (
                     !clientDetails[ip].adapterObjects.channels.includes(_channels.rows[currDevice].id) &&
                     _channels.rows[currDevice].id.split('.')[2] === clientDetails[ip].deviceName

--- a/main.js
+++ b/main.js
@@ -166,6 +166,28 @@ class Esphome extends utils.Adapter {
         }
     }
 
+    /**
+     * Warn when a version is left at "Always last available". Such a setup can break without any
+     * change on the user side as soon as an ESPHome release cannot be installed (#463), and the
+     * pinned defaults only apply to new installations - existing ones have to be adjusted by hand.
+     *
+     * @param {string} useDashBoardVersion - ESPHome Dashboard version which will be installed
+     * @param {string} usePillowVersion - Pillow version which will be installed
+     */
+    warnUnpinnedVersions(useDashBoardVersion, usePillowVersion) {
+        if (this.config.ESPHomeDashboardVersion === 'Always last available') {
+            this.log.warn(
+                `ESPHome Dashboard version is set to "Always last available" and resolves to ${useDashBoardVersion || 'the newest release'}. Not every ESPHome release can be installed on every system. If the dashboard does not start, select a fixed version in the adapter configuration, ${defaultDashboardVersion} is known to work.`,
+            );
+        }
+
+        if (this.config.PillowVersion === 'Always last available') {
+            this.log.warn(
+                `Pillow version is set to "Always last available" and resolves to ${usePillowVersion || 'the newest release'}. If the dashboard does not start, select a fixed version in the adapter configuration, ${defaultPillowVersion} is known to work.`,
+            );
+        }
+    }
+
     // ToDo: move to separate module
     async espHomeDashboard() {
         try {
@@ -274,6 +296,8 @@ class Esphome extends utils.Adapter {
             // Start Dashboard Process
             if (this.config.ESPHomeDashboardEnabled) {
                 this.log.info(`Native Integration of ESPHome Dashboard enabled, making environment ready`);
+
+                this.warnUnpinnedVersions(useDashBoardVersion, usePillowVersion);
                 try {
                     // @ts-expect-error autopy types are incomplete
                     const { getVenv } = await import('autopy');

--- a/test/integrationTests/dashboard_tests.js
+++ b/test/integrationTests/dashboard_tests.js
@@ -46,14 +46,17 @@ async function isDashboardReachable(port, maxAttempts, delayMs) {
         try {
             const accessible = await new Promise(resolve => {
                 const req = http.get(`http://localhost:${port}/`, res => {
-                    console.log(`Dashboard check attempt ${attempt}: HTTP ${res.statusCode}`);
+                    // statusCode is only absent when the response never completed, treat that as unreachable
+                    const statusCode = res.statusCode ?? 0;
+                    console.log(`Dashboard check attempt ${attempt}: HTTP ${statusCode}`);
                     // Dashboard is reachable if we get a successful response (2xx) or redirect (3xx)
                     // This indicates the dashboard server is running and responding properly
-                    resolve(res.statusCode >= 200 && res.statusCode < 400);
+                    resolve(statusCode >= 200 && statusCode < 400);
                 });
 
                 req.on('error', err => {
-                    console.log(`Dashboard check attempt ${attempt}: ${err.code || err.message}`);
+                    const code = /** @type {NodeJS.ErrnoException} */ (err).code;
+                    console.log(`Dashboard check attempt ${attempt}: ${code || err.message}`);
                     resolve(false);
                 });
 
@@ -68,7 +71,8 @@ async function isDashboardReachable(port, maxAttempts, delayMs) {
                 return true;
             }
         } catch (err) {
-            console.log(`Dashboard check attempt ${attempt} error: ${err.message}`);
+            const reason = err instanceof Error && err.message ? err.message : String(err);
+            console.log(`Dashboard check attempt ${attempt} error: ${reason}`);
         }
 
         if (attempt < maxAttempts) {
@@ -138,7 +142,8 @@ Check the adapter logs above for more details`;
                 console.log('✓ Dashboard integration test passed completely');
                 expect(isReachable).to.be.true;
             } catch (error) {
-                console.error(`Dashboard integration test failed: ${error.message}`);
+                const reason = error instanceof Error && error.message ? error.message : String(error);
+                console.error(`Dashboard integration test failed: ${reason}`);
                 throw error;
             } finally {
                 // Ensure the adapter (and thus the dashboard process) is always stopped
@@ -148,7 +153,11 @@ Check the adapter logs above for more details`;
                         await harness.stopAdapter();
                     }
                 } catch (cleanupError) {
-                    console.error(`Failed to stop adapter during dashboard test cleanup: ${cleanupError.message}`);
+                    const reason =
+                        cleanupError instanceof Error && cleanupError.message
+                            ? cleanupError.message
+                            : String(cleanupError);
+                    console.error(`Failed to stop adapter during dashboard test cleanup: ${reason}`);
                 }
             }
         });

--- a/test/integrationTests/version_fetch_tests.js
+++ b/test/integrationTests/version_fetch_tests.js
@@ -84,7 +84,8 @@ exports.runTests = function (suite) {
 
                 console.log('✓ Version fetching test passed completely');
             } catch (error) {
-                console.error(`Version fetch test failed: ${error.message}`);
+                const reason = error instanceof Error && error.message ? error.message : String(error);
+                console.error(`Version fetch test failed: ${reason}`);
                 throw error;
             } finally {
                 // Ensure the adapter is always stopped
@@ -94,7 +95,11 @@ exports.runTests = function (suite) {
                         await harness.stopAdapter();
                     }
                 } catch (cleanupError) {
-                    console.error(`Failed to stop adapter during version fetch test cleanup: ${cleanupError.message}`);
+                    const reason =
+                        cleanupError instanceof Error && cleanupError.message
+                            ? cleanupError.message
+                            : String(cleanupError);
+                    console.error(`Failed to stop adapter during version fetch test cleanup: ${reason}`);
                 }
             }
         });

--- a/test/testDashboardApi.js
+++ b/test/testDashboardApi.js
@@ -16,16 +16,29 @@ const dashboardApi = require('../lib/dashboardApi');
  *
  * @param {number} status - HTTP status code to simulate
  * @param {object|null} body - Response body to return from .json()
- * @returns {() => Promise<object>} Async function that returns a mock Response-like object
+ * @returns {typeof globalThis.fetch} Mock fetch resolving to a Response with the given status/body
  */
 function mockFetch(status, body) {
     const ok = status >= 200 && status < 300;
-    return async () => ({
-        ok,
-        status,
-        statusText: ok ? 'OK' : status === 404 ? 'Not Found' : 'Error',
-        json: async () => body,
-    });
+    return async () =>
+        new Response(JSON.stringify(body), {
+            status,
+            statusText: ok ? 'OK' : status === 404 ? 'Not Found' : 'Error',
+            headers: { 'content-type': 'application/json' },
+        });
+}
+
+/**
+ * Helper – create a mock fetch that records the requested URL and answers with an empty body.
+ *
+ * @param {(url: string) => void} onRequest - Called with the URL the client requested
+ * @returns {typeof globalThis.fetch} Mock fetch recording the requested URL
+ */
+function capturingFetch(onRequest) {
+    return async url => {
+        onRequest(String(url));
+        return new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+    };
 }
 
 describe('Dashboard API – request()', () => {
@@ -41,10 +54,7 @@ describe('Dashboard API – request()', () => {
 
     it('should build correct URL from dashboardUrl and path', async () => {
         let capturedUrl;
-        globalThis.fetch = async url => {
-            capturedUrl = url;
-            return { ok: true, status: 200, json: async () => ({}) };
-        };
+        globalThis.fetch = capturingFetch(url => (capturedUrl = url));
 
         await dashboardApi.request('GET', 'http://localhost:6052', 'devices');
         expect(capturedUrl).to.equal('http://localhost:6052/devices');
@@ -52,10 +62,7 @@ describe('Dashboard API – request()', () => {
 
     it('should strip a trailing slash from dashboardUrl', async () => {
         let capturedUrl;
-        globalThis.fetch = async url => {
-            capturedUrl = url;
-            return { ok: true, status: 200, json: async () => ({}) };
-        };
+        globalThis.fetch = capturingFetch(url => (capturedUrl = url));
 
         await dashboardApi.request('GET', 'http://localhost:6052/', 'devices');
         expect(capturedUrl).to.equal('http://localhost:6052/devices');
@@ -63,10 +70,7 @@ describe('Dashboard API – request()', () => {
 
     it('should append query parameters to the URL', async () => {
         let capturedUrl;
-        globalThis.fetch = async url => {
-            capturedUrl = url;
-            return { ok: true, status: 200, json: async () => ({}) };
-        };
+        globalThis.fetch = capturingFetch(url => (capturedUrl = url));
 
         await dashboardApi.request('GET', 'http://localhost:6052', 'json-config', {
             configuration: 'my-device.yaml',
@@ -89,8 +93,9 @@ describe('Dashboard API – request()', () => {
             await dashboardApi.request('GET', 'http://localhost:6052', 'devices');
             expect.fail('Expected an error to be thrown');
         } catch (err) {
-            expect(err.message).to.include('500');
-            expect(err.status).to.equal(500);
+            // Asserted through chai so the caught value stays "unknown" for the type checker
+            expect(err).to.have.property('message').that.includes('500');
+            expect(err).to.have.property('status', 500);
         }
     });
 });
@@ -151,7 +156,7 @@ describe('Dashboard API – getConfig()', () => {
             await dashboardApi.getConfig('http://localhost:6052', 'device.yaml');
             expect.fail('Expected an error to be thrown');
         } catch (err) {
-            expect(err.status).to.equal(503);
+            expect(err).to.have.property('status', 503);
         }
     });
 });


### PR DESCRIPTION
Consolidates everything queued for the 1.0 release. Started as the version pinning from https://github.com/DrozmotiX/ioBroker.esphome/issues/463#issuecomment-5108828310; the type error cleanup originally opened as #473 was merged in here so the release sits on one branch.

## 1. Pinned dashboard versions (#463)

`io-package.json` `native` defaults move from `"Always last available"` to the last combination known to work:

| setting | before | after |
| --- | --- | --- |
| `ESPHomeDashboardVersion` | `Always last available` | `2026.6.5` |
| `PillowVersion` | `Always last available` | `12.2.0` |

Both are present on PyPI; the 2026.7.x line is what currently fails to install (`Could not find a version that satisfies the requirement esphome==2026.7.3`).

**Existing installations are deliberately not rewritten.** The defaults only apply to fresh installs — anyone already running, including users who intentionally picked `Always last available`, keeps their configuration.

## 2. Startup warning for unpinned installations

Because of that, an existing installation would otherwise stay broken with nothing in the log pointing at the cause. When `Always last available` is configured and the native dashboard integration is enabled, the adapter now logs:

> ESPHome Dashboard version is set to "Always last available" and resolves to 2026.7.3. Not every ESPHome release can be installed on every system. If the dashboard does not start, select a fixed version in the adapter configuration, 2026.6.5 is known to work.

Same for Pillow. Nothing is written to the config — the user stays in control.

Supporting: both version dropDowns now guarantee the shipped default is selectable (`ensureVersionInDropDown`), and the Pillow fallback list — stale at `11.3.0`, so it did not even contain the new default — was refreshed.

## 3. `npm run check` is clean: 85 → 0 type errors

Two of them were real bugs, not missing annotations:

- **The "fall back to the latest release" path was broken.** It pushed a requirement without a `version`. autopy builds the pip argument as `` `${name}${version}` `` and feeds the same field to pep440 `satisfies()`, so that path asked pip for `esphomeundefined` — and in practice threw before getting that far, since `satisfies(version, undefined)` raises. Directly relevant to #463: this is the path taken whenever a version cannot be determined. An empty specifier means "any version" for both.
- **`ESPHomeDashboardPort` was passed to execa as a number** although the argument list is typed and documented as strings.

Also surfaced: `pingInterval` and `pingAttempts` are configured in jsonConfig but were missing from `io-package.json` `native`, so they were absent from `AdapterConfig`. Added with the defaults jsonConfig already uses (5 and 1) — no behaviour change, the code fell back to the same numbers.

The rest are annotations and narrowing:

| area | n | fix |
| --- | --- | --- |
| `errorHandler()` call sites | 19 | signature takes `unknown` instead of `Error\|string`; anything can be thrown in JS and the body already handled it |
| `catch` bindings across `main.js`, `lib/`, tests | 14 | narrowed with `instanceof Error` before reading `.message` / `.stack` |
| `lib/helpers.js` | 12 | `DeviceInfo` fields default to `null`, so TS inferred their type as exactly `null`. Declared `string \| null` |
| `lib/dashboardApi.js` | 5 | `WebSocketImpl` stayed possibly-null across the fallback assignment, and the `ws` instance was typed as a native `WebSocket`, which has no `.on()` |
| `test/testDashboardApi.js` | 3 | mocks returned a `{ok, status, json}` literal where `Response` was required; they build a real `Response` now |
| stale `@ts-expect-error` | 5 | no longer suppressed anything, reported as unused |
| `state.val` coercions, `modify()` regex | 8 | explicit `Number()` / `String()`; the regex match went straight into `parseFloat` relying on array-to-string coercion, now via `modifyArgument()` |

`modify()` was the only refactor with behavioural risk — I verified `modifyArgument()` returns identical `parseFloat`/`parseInt` results for every supported method (`multiply`, `divide`, `round`, `add`, `substract`, plus the no-argument case), and that `Number(value)` matches the previous implicit coercion for string, number and boolean inputs.

### One config change

`jsdoc/check-tag-names` is relaxed to `{ typed: false }` for JS files in `eslint.config.mjs`. `@iobroker/eslint-config` inherits jsdoc's `recommended-typescript` preset, which reports `@type` / `@typedef` as redundant "when using a type system". True for TypeScript sources, false for a JavaScript adapter type checked through `checkJs` — JSDoc is the only place a type can be written here.

## Verification

- `npm run check`: **0 errors** (was 85)
- `npm run lint`: clean, zero warnings
- `npm run format:check`: clean
- `npm run test:js` (16 passing), `npm run test:package` (57 passing), `npm run test:integration` (1 passing, 2 pending)

Note: the two dashboard integration suites are pending by default (they need `ESPHOME_RUN_DASHBOARD_TESTS=true`, build a real Python venv and install esphome from PyPI), so the edits in those two files were not executed — they are type-only, with logging output unchanged.

Refs #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)